### PR TITLE
fix: Make cmdline ARGS optional and change 'download_url' parameter

### DIFF
--- a/code/sum.py
+++ b/code/sum.py
@@ -96,6 +96,7 @@ def get_summary(filename="1.mp4", subtitles="1.srt"):
     return True
 
 def download_video(url):
+    print url
     yt = YouTube(url)
     yt.set_filename('1')
     video = yt.get('mp4')
@@ -104,8 +105,8 @@ def download_video(url):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser("Watch videos quickly")
-    parser.add_argument('-i', '--video-file', help="Input video file", required=True)
-    parser.add_argument('-s', '--subtitles-file', help="Input subtitle file (srt)", required=True)
+    parser.add_argument('-i', '--video-file', help="Input video file")
+    parser.add_argument('-s', '--subtitles-file', help="Input subtitle file (srt)")
     parser.add_argument('-u', '--url', help="Video url")
 
     args = parser.parse_args()
@@ -114,7 +115,7 @@ if __name__ == '__main__':
     if not url:
         get_summary(args.video_file, args.subtitles_file)
     else:
-        download_video(args.video_file)
+        download_video(url)
         # download subtitles
         # proceed with general summarization
 


### PR DESCRIPTION
Previously
- Requiring video-file and subtitle cmdline args interfere with downloading Youtube videos
- args.video_file is the incorrect parameter to be placed in 'download_url' function call at line 118
and leads to pyTube DoesNotExist Exception

Fixes
-Delete "required" parameter from commandline argument definitions
-Change download_url parameter from args.video_file to the 'url' variable

Closes:
Github issue #1
Github issue #2
Github issue #4