### PR TITLE
:bug: fix(bug fix): Selects highest resolution video for download

### DIFF
--- a/code/sum.py
+++ b/code/sum.py
@@ -105,7 +105,6 @@ def download_video(url):
     yt = YouTube(url)
     yt.set_filename('1')
     video = yt.filter('mp4')[-1]
-    # video = yt.get('mp4')
     video.download(os.getcwd())
     return True
 

--- a/code/sum.py
+++ b/code/sum.py
@@ -96,10 +96,16 @@ def get_summary(filename="1.mp4", subtitles="1.srt"):
     return True
 
 def download_video(url):
-    print url
+    ''' Downloads specified Youtube video
+    args:
+        url(str): Full url for youtube video
+    returns:
+        True
+    '''
     yt = YouTube(url)
     yt.set_filename('1')
-    video = yt.get('mp4')
+    video = yt.filter('mp4')[-1]
+    # video = yt.get('mp4')
     video.download(os.getcwd())
     return True
 


### PR DESCRIPTION
Prior to this change:
- If a download request is made for a video and
the video has multiple types and resolutions then a MultipleObjects Exception is raised
-extraneous print statement was left in download_video function

This change:
- uses pytube filter function to select a single video with the highest resolution for download
- deletes print statement

closes and addresses:
Github issue #6 
Github issue #7