### PR TITLE
fix : Get summary using a child process if a URL is provided

### DIFF
--- a/code/sum.py
+++ b/code/sum.py
@@ -4,6 +4,7 @@ import argparse
 import os
 import re
 from itertools import starmap
+import multiprocessing
 
 import pysrt
 import imageio
@@ -241,7 +242,9 @@ if __name__ == '__main__':
     else:
         # download video with subtitles
         movie_filename, subtitle_filename = download_video_srt(url)
-        get_summary(filename=movie_filename, subtitles=subtitle_filename)
+        summary_retrieval_process = multiprocessing.Process(target=get_summary, args=(movie_filename, subtitle_filename))
+        summary_retrieval_process.start()
+        summary_retrieval_process.join()
         if not keep_original_file:
             os.remove(movie_filename)
             os.remove(subtitle_filename)


### PR DESCRIPTION
moviepy does not close files until garbage collection is done. The fix calls a function using moviepy through a child process, so that  the usage of the relevant resources stops as soon as the function is done, and said resources can be manipulated by the parent process.

Fixes issue #38.